### PR TITLE
Fix loop that never returns on error

### DIFF
--- a/exporter/http.go
+++ b/exporter/http.go
@@ -40,7 +40,7 @@ func asyncHTTPGets(targets []string, token string) ([]*Response, error) {
 		case r := <-ch:
 			if r.err != nil {
 				log.Errorf("Error scraping API, Error: %v", r.err)
-				break
+				return nil, r.err
 			}
 			responses = append(responses, r)
 

--- a/test/github_exporter_test.go
+++ b/test/github_exporter_test.go
@@ -55,6 +55,22 @@ func TestGithubExporter(t *testing.T) {
 		End()
 }
 
+func TestGithubExporterHttpErrorHandling(t *testing.T) {
+	test, collector := apiTest(withConfig("myOrg/myRepo"))
+	defer prometheus.Unregister(&collector)
+
+	// Test that the exporter returns when an error occurs
+	// Ideally a new gauge should be added to keep track of scrape errors
+	// following prometheus exporter guidelines
+	test.Mocks(
+		githubPullsError(),
+	).
+		Get("/metrics").
+		Expect(t).
+		Status(http.StatusOK).
+		End()
+}
+
 func apiTest(conf config.Config) (*apitest.APITest, exporter.Exporter) {
 	exp := exporter.Exporter{
 		APIMetrics: exporter.AddMetrics(),
@@ -116,6 +132,15 @@ func githubPulls() *apitest.Mock {
 		Times(2).
 		Body(readFile("testdata/pulls_response.json")).
 		Status(http.StatusOK).
+		End()
+}
+
+func githubPullsError() *apitest.Mock {
+	return apitest.NewMock().
+		Get("https://api.github.com/repos/myOrg/myRepo/pulls").
+		Header("Authorization", "token 12345").
+		RespondWith().
+		Status(http.StatusBadRequest).
 		End()
 }
 


### PR DESCRIPTION
  - While running this exporter in the grafana agent, we have identified a loop that never returns in case of http error. This in turn causes the agent to never release a lock, preventing it from making progress.
  - Note: I have not added additional metrics to report errors as I am trying to keep the scope of this change minimal, but it would be a good idea to add a gauge as stated in the [prometheus guidelies](https://prometheus.io/docs/instrumenting/writing_exporters/#failed-scrapes)